### PR TITLE
fix modal/dimmer inverted bug #3192

### DIFF
--- a/src/definitions/modules/dimmer.js
+++ b/src/definitions/modules/dimmer.js
@@ -383,10 +383,11 @@ $.fn.dimmer = function(parameters) {
             var
               color      = $dimmer.css('background-color'),
               colorArray = color.split(','),
+              isRGB      = (colorArray && colorArray.length == 3),
               isRGBA     = (colorArray && colorArray.length == 4)
             ;
             opacity    = settings.opacity === 0 ? 0 : settings.opacity || opacity;
-            if(isRGBA) {
+            if(isRGB || isRGBA) {
               colorArray[3] = opacity + ')';
               color         = colorArray.join(',');
             }


### PR DESCRIPTION
During the second dimmer run the color was extracted from the DOM. At
least Firefox automatically converts RGBA to RGB if possible which
caused the bug.

With this fix the dimmer module can now detect both RGB and RGBA colors.
